### PR TITLE
Set up CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,9 @@ dist/
 *.egg
 *.egg-info/
 
-# mypy cache
-.mypy_cache/
-
 # Python virtal env
 .venv/
+
+# Tooling artifacts
+.mypy_cache/
+.tox/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: python
+python:
+  - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.8-dev"
+  - "nightly"
+  - "pypy3"
+install:
+  - pip install tox
+script:
+  - tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,11 @@ matrix:
       env: TOXENV=py38
     - python: pypy3
       env: TOXENV=pypy3
+    - python: nightly
+  allow_failures:
+    # Nightly is included so we get early warnings of failures, but it's
+    # unstable so we let it fail
+    - python: nightly
 install:
   - pip install tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: python
-python:
-  - "3.6"
-  - "3.7"
-  - "3.8"
-  - "3.8-dev"
-  - "nightly"
-  - "pypy3"
+matrix:
+  include:
+    - python: 3.6
+      env: TOXENV=py36
+    - python: 3.7
+      env: TOXENV=py37
+    - python: 3.8
+      env: TOXENV=py38
+    - python: pypy3
+      env: TOXENV=pypy3
 install:
   - pip install tox
 script:

--- a/README.md
+++ b/README.md
@@ -6,17 +6,27 @@ Interoperability client for the Aerial Robotics Club at NC State.
 
 ## Development
 
-Since we do not yet have a CI pipeline for this project, run the following
-commands before merging any pull request. If you used [poetry] to set up your
-virtualenv, you should already have all dependencies for the following
-commands!
+We use [tox] as our test automation tool. If you don't already have it
+installed, we strongly recommend you do because it will automatically set up
+your test environment and run all of our checks. Usage is as simple as
 
 ```sh
-poetry run mypy .
-poetry run flake8
-poetry run pytest
-poetry run black --check .
-poetry run isort --check-only
+# If you don't already have tox installed, install it
+$ pip install --user tox
+# Run the tests!
+$ tox
 ```
+
+[tox]: https://tox.readthedocs.io/en/latest/
+
+This performs the same checks that [Travis] will run on every PR.
+
+[Travis]: https://travis-ci.com/github/ncsuarc/interop_clients
+
+For manual testing, we recommend [poetry] as your Python virtual environment
+manager. It will automatically install all dependencies into a local venv and
+should integrate with your editor nicely. We won't go over usage extensively
+here, but use `poetry run` to run one-off commands in your virtualenv and
+`poetry shell` to activate your virtualenv.
 
 [poetry]: https://python-poetry.org/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # interop_clients
 
+[![Build Status](https://travis-ci.com/ncsuarc/interop_clients.svg?branch=master)](https://travis-ci.com/ncsuarc/interop_clients)
+
 Interoperability client for the Aerial Robotics Club at NC State.
 
 ## Development

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+[tox]
+; Work with pyproject.toml and PEP 517
+isolated_build = True
+; Just use the current Python
+envlist = py3
+
+[testenv]
+; Keep going if one command fails. Our commands don't depend on each other, so
+; we want as much output as possible in a single run
+ignore_errors = True
+
+deps =
+    mypy
+    flake8
+    flake8-bugbear
+    pytest
+    black
+    isort
+commands =
+    mypy interop_clients
+    flake8 interop_clients
+    pytest interop_clients
+    black --check interop_clients
+    isort --check-only


### PR DESCRIPTION
This sets up CI using Travis + tox, which is what we've used for our other projects like [FuzzySortedDict](https://github.com/ncsuarc/FuzzySortedDict). This builds against python 3.6, python 3.7, python 3.8, and pypy3. It also builds against python nightly, but that is allowed to fail.

As of right now, none of the builds pass! This is because of some mypy and flake8 warnings, although pypy3 and nightly seem to have real issues that may be outside of our control.