### PR TITLE
Separate linting from testing in tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 matrix:
   include:
+    - python: 3.8
+      env: TOXENV=lint
     - python: 3.6
       env: TOXENV=py36
     - python: 3.7
@@ -10,6 +12,7 @@ matrix:
     - python: pypy3
       env: TOXENV=pypy3
     - python: nightly
+      env: TOXENV=py3
   allow_failures:
     # Nightly is included so we get early warnings of failures, but it's
     # unstable so we let it fail

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,13 @@
 ; Work with pyproject.toml and PEP 517
 isolated_build = True
 ; Just use the current Python
-envlist = py3
+envlist = py3,lint
 
 [testenv]
+deps = pytest
+commands = pytest interop_clients
+
+[testenv:lint]
 ; Keep going if one command fails. Our commands don't depend on each other, so
 ; we want as much output as possible in a single run
 ignore_errors = True
@@ -13,12 +17,10 @@ deps =
     mypy
     flake8
     flake8-bugbear
-    pytest
     black
     isort
 commands =
     mypy interop_clients
     flake8 interop_clients
-    pytest interop_clients
     black --check interop_clients
     isort --check-only


### PR DESCRIPTION
This speeds up our CI by only doing linting in a single build instead of all builds. This also makes it easier to view the results of tests and linting separately.